### PR TITLE
Publish website to GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+      - master
       - 'v[0-9]+.[0-9]+'
       - releng/**
     tags:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - main
+      - master
       - 'v[0-9]+.[0-9]+'
       - checks-workflow-dev/*
     tags:

--- a/.github/workflows/doc-ci-cd.yml
+++ b/.github/workflows/doc-ci-cd.yml
@@ -1,0 +1,63 @@
+# Copyright (c) Jiaqi Liu
+name: Documentation CI/CD
+
+'on':
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  documentation-ci-cd:
+    name: Test & Release Documentation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18  # must be 18 or above to avoid "Cannot read properties of undefined (reading 'version')"
+      - name: Test documentation build
+        run: npm run build
+      - name: Bundle up a GitHub Pages Deployable
+        if: github.ref == 'refs/heads/master'
+        run: |
+          mkdir hashicorp-terraform-docs
+          cp -r website-preview/.next/server/pages/* hashicorp-terraform-docs
+          
+          mkdir hashicorp-terraform-docs/_next
+          cp -r website-preview/.next/static hashicorp-terraform-docs/_next/static
+          
+          # The next command is not allowed by shellcheck. https://www.linuxjournal.com/content/bash-extended-globbing
+          # IMMUTABLE_DEPLOY_ARTIFACT_ID=$(ls website-preview/.next/static/ | grep -Ev "chunks|images|css|media")
+          # So we replace it with "find" command below
+          # Reference:
+          #   https://stackoverflow.com/a/6745470
+          #   https://stackoverflow.com/a/13525005
+          #   https://superuser.com/a/1016521
+          #   https://stackoverflow.com/a/7715567
+          IMMUTABLE_DEPLOY_ARTIFACT_ID=$(
+            find website-preview/.next/static/ \
+                -not -name images \
+                -not -name chunks \
+                -not -name css \
+                -not -name media \
+                -mindepth 1 \
+                -maxdepth 1 \
+                -execdir echo {} ';'
+          )
+          mkdir -p hashicorp-terraform-docs/_next/data/"${IMMUTABLE_DEPLOY_ARTIFACT_ID}"
+          cp -r website-preview/.next/server/pages/* hashicorp-terraform-docs/_next/data/"${IMMUTABLE_DEPLOY_ARTIFACT_ID}"
+          
+          cd hashicorp-terraform-docs/
+          touch .nojekyll
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: website/hashicorp-terraform-docs
+          user_name: QubitPi
+          user_email: jack20191124@proton.me

--- a/website/README.md
+++ b/website/README.md
@@ -1,3 +1,7 @@
+See [more details on how documentation is build][Forked HashiCorp Dev Portal]
+
+[Forked HashiCorp Dev Portal]: https://github.com/QubitPi/hashicorp-dev-portal
+
 # Terraform Documentation
 
 This directory contains the portions of [the Terraform website](https://www.terraform.io/) that pertain to the core functionality, excluding providers and the overall configuration.

--- a/website/scripts/website-build.sh
+++ b/website/scripts/website-build.sh
@@ -7,7 +7,7 @@
 ######################################################
 
 # Repo which we are cloning and executing npm run build:deploy-preview within
-REPO_TO_CLONE=dev-portal
+REPO_TO_CLONE=hashicorp-dev-portal
 # Set the subdirectory name for the base project
 PREVIEW_DIR=website-preview
 # The directory we want to clone the project into
@@ -34,7 +34,7 @@ fi
 
 # Clone the base project, if needed
 echo "⏳ Cloning the $REPO_TO_CLONE repo, this might take a while..."
-git clone --depth=1 "https://github.com/hashicorp/$REPO_TO_CLONE.git" "$CLONE_DIR"
+git clone --depth=1 "https://github.com/QubitPi/$REPO_TO_CLONE.git" "$CLONE_DIR"
 
 if [ "$from_cache" = true ]; then
   echo "Setting up $PREVIEW_DIR"
@@ -52,4 +52,5 @@ REPO=$PRODUCT \
 HASHI_ENV=project-preview \
 LOCAL_CONTENT_DIR=$LOCAL_CONTENT_DIR \
 CURRENT_GIT_BRANCH=$CURRENT_GIT_BRANCH \
+PRODUCT_DOC_BASE_PATH=/hashicorp-terraform \
 npm run build:deploy-preview

--- a/website/scripts/website-start.sh
+++ b/website/scripts/website-start.sh
@@ -7,7 +7,7 @@
 ######################################################
 
 # Repo which we are cloning and executing npm run build:deploy-preview within
-REPO_TO_CLONE=dev-portal
+REPO_TO_CLONE=hashicorp-dev-portal
 # Set the subdirectory name for the dev-portal app
 PREVIEW_DIR=website-preview
 # The product for which we are building the deploy preview
@@ -27,7 +27,7 @@ should_pull=true
 # Clone the dev-portal project, if needed
 if [ ! -d "$PREVIEW_DIR" ]; then
     echo "⏳ Cloning the $REPO_TO_CLONE repo, this might take a while..."
-    git clone --depth=1 https://github.com/hashicorp/$REPO_TO_CLONE.git "$PREVIEW_DIR"
+    git clone --depth=1 https://github.com/QubitPi/$REPO_TO_CLONE.git "$PREVIEW_DIR"
     should_pull=false
 fi
 
@@ -44,4 +44,5 @@ PREVIEW_FROM_REPO=$PRODUCT \
 LOCAL_CONTENT_DIR=$LOCAL_CONTENT_DIR \
 CURRENT_GIT_BRANCH=$CURRENT_GIT_BRANCH \
 PREVIEW_MODE=$PREVIEW_MODE \
+PRODUCT_DOC_BASE_PATH=/hashicorp-terraform \
 npm run start:local-preview


### PR DESCRIPTION
- Add documentation CI/CD

  - Any pull request triggers the documentation test build
  - Any commits to `master` branch triggers the same test build and then automatically deploys the documentation to GitHub Pages

- All GitHub actions that targets upstream `main` also triggers on `master`, which is the default branch of this fork